### PR TITLE
Versao 4.1.1 correcoes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 3. Editar o arquivo "/sei/config/ConfiguracaoSEI.php", tomando o cuidado de usar editor que não altere o charset do arquivo, para adicionar a referência à classe de integração do módulo e seu caminho relativo dentro da pasta "/sei/web/modulos" na array 'Modulos' da chave 'SEI':
 
 		'SEI' => array(
-			...
-			'Modulos' => array(
-				'PesquisaIntegracao' => 'pesquisa',
-				),
+			'URL' => 'http://[Servidor_PHP]/sei',
+			'Producao' => false,
+			'RepositorioArquivos' => '/var/sei/arquivos',
+			'Modulos' => array('PesquisaIntegracao' => 'pesquisa',)
 			),
 
 4. Antes de seguir para os próximos passos, é importante conferir se o Módulo foi corretamente declarado no arquivo "/sei/config/ConfiguracaoSEI.php". Acesse o menu **Infra > Módulos** e confira se consta a linha correspondente ao Módulo, pois, realizando os passos anteriores da forma correta, independente da execução do script de banco, o Módulo já deve ser reconhecido na tela aberta pelo menu indicado.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 3. Editar o arquivo "/sei/config/ConfiguracaoSEI.php", tomando o cuidado de usar editor que não altere o charset do arquivo, para adicionar a referência à classe de integração do módulo e seu caminho relativo dentro da pasta "/sei/web/modulos" na array 'Modulos' da chave 'SEI':
 
 		'SEI' => array(
-			'URL' => 'http://[Servidor_PHP]/sei',
-			'Producao' => false,
-			'RepositorioArquivos' => '/var/sei/arquivos',
-			'Modulos' => array('PesquisaIntegracao' => 'pesquisa',)
+			...
+			'Modulos' => array(
+				'PesquisaIntegracao' => 'pesquisa',
+				),
 			),
 
 4. Antes de seguir para os próximos passos, é importante conferir se o Módulo foi corretamente declarado no arquivo "/sei/config/ConfiguracaoSEI.php". Acesse o menu **Infra > Módulos** e confira se consta a linha correspondente ao Módulo, pois, realizando os passos anteriores da forma correta, independente da execução do script de banco, o Módulo já deve ser reconhecido na tela aberta pelo menu indicado.

--- a/sei/web/modulos/pesquisa/PesquisaIntegracao.php
+++ b/sei/web/modulos/pesquisa/PesquisaIntegracao.php
@@ -8,7 +8,7 @@
 		
 		public function getVersao()
 		{
-			return '4.1.0';
+			return '4.1.1';
 		}
 		
 		
@@ -74,7 +74,7 @@
 				if(is_array($arrModulos) && array_key_exists('PesquisaIntegracao', $arrModulos)){
 					$caminho = $arrModulos['PesquisaIntegracao'];
 					$arrMenu = array();
-					$arrMenu[] = '-^'.ConfiguracaoSEI::getInstance()->getValor('SEI','URL').'/modulos/'.$caminho.'/md_pesq_processo_pesquisar.php?acao_externa=protocolo_pesquisar&acao_origem_externa=protocolo_pesquisar&id_orgao_acesso_externo=0^^Pesquisa Pública^_blank^';
+					$arrMenu[] = '-^'.ConfiguracaoSEI::getInstance()->getValor('SEI','URL').'/modulos/'.$caminho.'/md_pesq_processo_pesquisar.php?acao_externa=protocolo_pesquisar&acao_origem_externa=protocolo_pesquisar&id_orgao_acesso_externo='.$_GET['id_orgao_acesso_externo'].'^^Pesquisa Pública^_blank^';
 					return $arrMenu;
 				}
 			}

--- a/sei/web/modulos/pesquisa/README.md
+++ b/sei/web/modulos/pesquisa/README.md
@@ -16,10 +16,10 @@
 3. Editar o arquivo "/sei/config/ConfiguracaoSEI.php", tomando o cuidado de usar editor que não altere o charset do arquivo, para adicionar a referência à classe de integração do módulo e seu caminho relativo dentro da pasta "/sei/web/modulos" na array 'Modulos' da chave 'SEI':
 
 		'SEI' => array(
-			'URL' => 'http://[Servidor_PHP]/sei',
-			'Producao' => false,
-			'RepositorioArquivos' => '/var/sei/arquivos',
-			'Modulos' => array('PesquisaIntegracao' => 'pesquisa',)
+			...
+			'Modulos' => array(
+				'PesquisaIntegracao' => 'pesquisa',
+				),
 			),
 
 4. Antes de seguir para os próximos passos, é importante conferir se o Módulo foi corretamente declarado no arquivo "/sei/config/ConfiguracaoSEI.php". Acesse o menu **Infra > Módulos** e confira se consta a linha correspondente ao Módulo, pois, realizando os passos anteriores da forma correta, independente da execução do script de banco, o Módulo já deve ser reconhecido na tela aberta pelo menu indicado.

--- a/sei/web/modulos/pesquisa/md_pesq_documento_consulta_externa.php
+++ b/sei/web/modulos/pesquisa/md_pesq_documento_consulta_externa.php
@@ -52,10 +52,10 @@ try {
 	$objDocumentoRN = new DocumentoRN();
 	$objDocumentoDTO = $objDocumentoRN->consultarRN0005($objDocumentoDTO);
 
-	$isLocalPublico = $objDocumentoDTO->getStrStaNivelAcessoGlobalProtocolo() == ProtocoloRN::$NA_PUBLICO;
+	$isLocalPublico = $objDocumentoDTO->getStrStaNivelAcessoLocalProtocolo() == ProtocoloRN::$NA_PUBLICO;
 	$isGlobalPublico = $objDocumentoDTO->getStrStaNivelAcessoGlobalProtocolo() == ProtocoloRN::$NA_PUBLICO;
 
-	if ($objDocumentoDTO==null || !$bolLinkMetadadosProcessoRestrito){
+	if ($objDocumentoDTO == null || (!$isGlobalPublico && !$bolLinkMetadadosProcessoRestrito)){
 	 die('Documento não encontrado.');
 	}
 

--- a/sei/web/modulos/pesquisa/md_pesq_processo_exibir.php
+++ b/sei/web/modulos/pesquisa/md_pesq_processo_exibir.php
@@ -260,7 +260,7 @@ try {
    	$strResultado = '<table id="tblDocumentos" width="99.3%" class="infraTable" summary="Lista de Documentos" >
   					  									<caption class="infraCaption" >'.PaginaSEIExterna::getInstance()->gerarCaptionTabela("Protocolos",$numProtocolos).'</caption> 
   					 									<tr>
-                                                            <th class="infraTh" width="1%">'.$strThCheck.'</th>  					  									    
+                                                            <th class="infraTh no-print" width="1%">'.$strThCheck.'</th>  					  									    
   					  										<th class="infraTh" width="15%">Processo / Documento</th> 
                                                             <th class="infraTh" width="15%">Tipo</th>
                                                             <th class="infraTh" width="15%">Data</th>
@@ -301,15 +301,15 @@ try {
                     }
 
 				    if($dtaCortePesquisa && $dtaCortePesquisa > date('Y-m-d', strtotime(str_replace('/', '-', $dtaCorteDoc)))) {
-                        $strResultado .= '<td>&nbsp;</td>';
+                        $strResultado .= '<td class="no-print">&nbsp;</td>';
 				    }else{
-                        $strResultado .= '<td align="center">'.PaginaSEIExterna::getInstance()->getTrCheck($numDocumentosPdf++, $objDocumentoDTO->getDblIdDocumento(), $objDocumentoDTO->getStrNomeSerie()).'</td>';
+                        $strResultado .= '<td align="center" class="no-print">'.PaginaSEIExterna::getInstance()->getTrCheck($numDocumentosPdf++, $objDocumentoDTO->getDblIdDocumento(), $objDocumentoDTO->getStrNomeSerie()).'</td>';
                     }
 				}else{
-   					$strResultado .= '<td>&nbsp;</td>';
+   					$strResultado .= '<td class="no-print">&nbsp;</td>';
    				}
    			}else{
-   				$strResultado .= '<td>&nbsp;</td>';
+   				$strResultado .= '<td class="no-print">&nbsp;</td>';
    			}
    			
    			//Exibe link de documentos com nivel de acesso local Publico de processo publico
@@ -391,7 +391,7 @@ try {
    	
    			
    			$strResultado .= '<tr class="infraTrClara">';
-   			$strResultado .= '<td>&nbsp;</td>';
+   			$strResultado .= '<td class="no-print">&nbsp;</td>';
    			$strHipoteseLegalAnexo = '';
    			$strProtocoloRestrito = '';
    			
@@ -465,6 +465,10 @@ try {
 		
 		$arrComandos[] = $strComando;
 		
+	}
+
+	if ($bolAcaoImprimir = true){
+		$arrComandos[] = '<button type="button" accesskey="I" id="btnImprimir" value="Imprimir" onclick="infraImprimirDiv(\'divInfraAreaTelaD\');" class="infraButton"><span class="infraTeclaAtalho">I</span>mprimir</button>';
 	}
  	
  	//Carregar historico
@@ -618,6 +622,12 @@ CaptchaSEI::getInstance()->montarStyle();
 PaginaSEIExterna::getInstance()->abrirStyle();
 echo $strCssMostrarAcoes;
 ?>
+
+@media print {
+    .infraBarraComandos, .infraBarraComandos *, .no-print, .no-print * {
+        display: none !important;
+    }
+}
 
 div.infraBarraSistemaE {width:90%}
 div.infraBarraSistemaD {width:5%}


### PR DESCRIPTION
## Correções desta Versão
1. Correção sobre o parâmetro da administração "Pesquisar e acessar processos com nível de acesso global Restrito", que quando era desativado (opção "Não") impactava indevidamente o acesso aos documentos públicos de Processo global público mesmo montando o link para acesso ao documento, sempre apresentando na janela aberta "Documento não encontrado".
2. Correção no link montado no menu incluído no Acesso Externo do SEI logado para pegar o id_orgao_acesso_externo dinamicamente na montagem do link da página de Pesquisa Pública, quando na administração de Parâmetros de Pesquisa é ativada a opção "Habilitar menu para a Pesquisa Pública no Acesso Externo do SEI".
	- Estava forçado para id_orgao_acesso_externo=0, quando instalações multi órgãos cada órgão possui URL de acesso externo própria com o seu id de órgão na instalação do SEI.

## Evoluções desta Versão
1. Evolução na tela de pesquisa e na modal do “Gerar PDF” para utilizar o novo componente de CAPTCHA do SEI 4.0, com opção de escutar o CAPTCHA em áudio.
2. Incluído botão "Imprimir" na tela de acesso ao processo, ao lado do botão "Gerar PDF".